### PR TITLE
Add disabled-by-default config for spawn check logging

### DIFF
--- a/src/main/java/net/xalcon/torchmaster/TorchmasterConfig.java
+++ b/src/main/java/net/xalcon/torchmaster/TorchmasterConfig.java
@@ -122,7 +122,7 @@ public class TorchmasterConfig
 
             logSpawnChecks = builder
                 .comment("Print entity spawn checks to the debug log")
-                .translation("torchmaster.config.debugLogging.description")
+                .translation("torchmaster.config.logSpawnChecks.description")
                 .define("logSpawnChecks", false);
 
             builder.pop();

--- a/src/main/java/net/xalcon/torchmaster/TorchmasterConfig.java
+++ b/src/main/java/net/xalcon/torchmaster/TorchmasterConfig.java
@@ -41,6 +41,8 @@ public class TorchmasterConfig
         public final ForgeConfigSpec.ConfigValue<Integer> feralFlareLanternLightCountHardcap;
         public final ForgeConfigSpec.ConfigValue<Integer> frozenPearlDurability;
 
+        public final ForgeConfigSpec.ConfigValue<Boolean> logSpawnChecks;
+
         private General(ForgeConfigSpec.Builder builder)
         {
             builder.push("General");
@@ -117,6 +119,11 @@ public class TorchmasterConfig
                 .comment("Durability of the frozen pearl. Each removed light will remove one charge from the pearl. Set to 0 to disable durability")
                 .translation("torchmaster.config.frozenPearlDurability.description")
                 .defineInRange("frozenPearlDurability", 1024, 0, Short.MAX_VALUE);
+
+            logSpawnChecks = builder
+                .comment("Print entity spawn checks to the debug log")
+                .translation("torchmaster.config.debugLogging.description")
+                .define("logSpawnChecks", false);
 
             builder.pop();
         }

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/EntityBlockingEventHandler.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/EntityBlockingEventHandler.java
@@ -6,7 +6,6 @@ import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -22,7 +21,8 @@ public class EntityBlockingEventHandler
     @SubscribeEvent
     public static void onCheckSpawn(LivingSpawnEvent.CheckSpawn event) throws InterruptedException
     {
-        Torchmaster.Log.debug("CheckSpawn - IsSpawner: {}, Reason: {}, Type: {}", event.isSpawner(), event.getSpawnReason(), event.getEntity().getType().getRegistryName());
+        boolean log = TorchmasterConfig.GENERAL.logSpawnChecks.get();
+        if (log) Torchmaster.Log.debug("CheckSpawn - IsSpawner: {}, Reason: {}, Type: {}", event.isSpawner(), event.getSpawnReason(), event.getEntity().getType().getRegistryName());
         event.getWorld().getWorld().getProfiler().startSection("torchmaster_checkspawn");
         if(event.getResult() == Event.Result.ALLOW) return;
         if(TorchmasterConfig.GENERAL.blockOnlyNaturalSpawns.get() && event.isSpawner()) return;
@@ -35,12 +35,12 @@ public class EntityBlockingEventHandler
             if(reg.shouldBlockEntity(entity))
             {
                 event.setResult(Event.Result.DENY);
-                Torchmaster.Log.debug("Blocking spawn of {}", event.getEntity().getType().getRegistryName());
+                if (log) Torchmaster.Log.debug("Blocking spawn of {}", event.getEntity().getType().getRegistryName());
                 //event.getEntity().addTag("torchmaster_removed_spawn");
             }
             else
             {
-                Torchmaster.Log.debug("Allowed spawn of {}", event.getEntity().getType().getRegistryName());
+                if (log) Torchmaster.Log.debug("Allowed spawn of {}", event.getEntity().getType().getRegistryName());
             }
         });
         event.getWorld().getWorld().getProfiler().endSection();


### PR DESCRIPTION
Torch Master ends up printing this *a lot* from my experience, and it's usually only useful if you are actively debugging the mod. This pull request implements a config to disable the debug logging by default, which aids to reduce log file sizes.