### PR TITLE
Fix missing localization and add beginner tooltips

### DIFF
--- a/src/main/java/net/xalcon/torchmaster/common/items/TMItemBlock.java
+++ b/src/main/java/net/xalcon/torchmaster/common/items/TMItemBlock.java
@@ -1,7 +1,16 @@
 package net.xalcon.torchmaster.common.items;
 
 import net.minecraft.block.Block;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraft.world.World;
+import net.xalcon.torchmaster.TorchmasterConfig;
+
+import javax.annotation.Nullable;
+import java.util.List;
 
 public class TMItemBlock extends BlockItem
 {
@@ -9,5 +18,13 @@ public class TMItemBlock extends BlockItem
     {
         super(blockIn, builder);
         this.setRegistryName(blockIn.getRegistryName());
+    }
+
+    @Override
+    public void addInformation(ItemStack stack, @Nullable World world, List<ITextComponent> tooltip, ITooltipFlag flag)
+    {
+        super.addInformation(stack, world, tooltip, flag);
+        if(TorchmasterConfig.GENERAL.beginnerTooltips.get())
+            tooltip.add(new TranslationTextComponent(this.getTranslationKey(stack) + ".tooltip"));
     }
 }

--- a/src/main/resources/assets/torchmaster/lang/en_us.json
+++ b/src/main/resources/assets/torchmaster/lang/en_us.json
@@ -1,6 +1,15 @@
 {
     "block.torchmaster.megatorch": "Mega Torch",
+    "block.torchmaster.megatorch.tooltip": "Prevents natural spawning of hostile monsters in a decent radius around the torch",
     "block.torchmaster.dreadlamp": "Dread Lamp",
+    "block.torchmaster.dreadlamp.tooltip": "Prevents natural spawning of passive animals like squids, bats or ocelots in a big radius around the lamp",
+    "block.torchmaster.feral_flare_lantern": "Feral Flare Lantern",
+    "block.torchmaster.feral_flare_lantern.tooltip": "Places invisible lights",
+    "block.torchmaster.invisible_light": "Invisible Light",
+    "item.torchmaster.frozen_pearl": "Frozen Pearl",
+    "item.torchmaster.frozen_pearl.tooltip": "Clears residual lights from a Feral Flare Lantern",
+    "command.torchmaster.torch_list.completed": "Torches have been dumped to the log file",
+    "command.torchmaster.entity_dump.completed": "Entities have been dumped to the log file",
     "itemGroup.torchmaster": "Torchmaster"
 }
 

--- a/src/main/resources/assets/torchmaster/lang/en_us.json
+++ b/src/main/resources/assets/torchmaster/lang/en_us.json
@@ -1,6 +1,6 @@
 {
     "block.torchmaster.megatorch": "Mega Torch",
-    "block.torchmaster.megatorch.tooltip": "Prevents natural spawning of hostile monsters in a decent radius around the torch",
+    "block.torchmaster.megatorch.tooltip": "Prevents natural spawning of hostile monsters in a big radius around the torch",
     "block.torchmaster.dreadlamp": "Dread Lamp",
     "block.torchmaster.dreadlamp.tooltip": "Prevents natural spawning of passive animals like squids, bats or ocelots in a big radius around the lamp",
     "block.torchmaster.feral_flare_lantern": "Feral Flare Lantern",


### PR DESCRIPTION
- Adds the missing localization for the feral flare lantern, frozen pearl, invisible light block, and command messages.
- Implements beginner tooltips for the mod's content. **The feral flare lantern tooltip needs review.**