### PR TITLE
Fix phantoms not being blocked.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ mod_version_release_suffix=
 
 mcp_mappings_channel=snapshot
 mcp_mappings_version=20200916-1.16.2
-forge_version=1.16.5-36.0.0
+forge_version=1.16.5-36.1.0

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/EntityBlockingEventHandler.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/EntityBlockingEventHandler.java
@@ -2,6 +2,7 @@ package net.xalcon.torchmaster.common.logic.entityblocking;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
@@ -29,10 +30,12 @@ public class EntityBlockingEventHandler
 
         Entity entity = event.getEntity();
         World world = entity.getEntityWorld();
+        
+        BlockPos pos = new BlockPos(event.getX(), event.getY(), event.getZ());
 
         world.getCapability(ModCaps.TEB_REGISTRY).ifPresent(reg ->
         {
-            if(reg.shouldBlockEntity(entity))
+            if(reg.shouldBlockEntity(entity, pos))
             {
                 event.setResult(Event.Result.DENY);
                 if (log) Torchmaster.Log.debug("Blocking spawn of {}", event.getEntity().getType().getRegistryName());

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/IEntityBlockingLight.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/IEntityBlockingLight.java
@@ -6,7 +6,7 @@ import net.minecraft.world.World;
 
 public interface IEntityBlockingLight
 {
-    boolean shouldBlockEntity(Entity entity);
+    boolean shouldBlockEntity(Entity entity, BlockPos pos);
     String getLightSerializerKey();
 
     String getName();

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/ITEBLightRegistry.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/ITEBLightRegistry.java
@@ -10,7 +10,7 @@ import net.xalcon.torchmaster.common.commands.TorchInfo;
 
 public interface ITEBLightRegistry extends INBTSerializable<CompoundNBT>
 {
-    boolean shouldBlockEntity(Entity entity);
+    boolean shouldBlockEntity(Entity entity, BlockPos pos);
 
     /**
      * Warning: The IEntityBlockingLight instance should not be directly attached to any chunk data!

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/LightsRegistryCapability.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/LightsRegistryCapability.java
@@ -157,12 +157,12 @@ public class LightsRegistryCapability implements ICapabilityProvider, ICapabilit
         }
 
         @Override
-        public boolean shouldBlockEntity(Entity entity)
+        public boolean shouldBlockEntity(Entity entity, BlockPos pos)
         {
             for(HashMap.Entry<String, IEntityBlockingLight> lightEntry : lights.entrySet())
             {
                 IEntityBlockingLight light = lightEntry.getValue();
-                if(light.shouldBlockEntity(entity))
+                if(light.shouldBlockEntity(entity, pos))
                     return true;
             }
             return false;

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/dreadlamp/DreadLampEntityBlockingLight.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/dreadlamp/DreadLampEntityBlockingLight.java
@@ -22,10 +22,10 @@ public class DreadLampEntityBlockingLight implements IEntityBlockingLight
     }
 
     @Override
-    public boolean shouldBlockEntity(Entity entity)
+    public boolean shouldBlockEntity(Entity entity, BlockPos pos)
     {
         return Torchmaster.DreadLampFilterRegistry.containsEntity(entity.getType().getRegistryName())
-            && DistanceLogics.Cubic.isPositionInRange(entity.lastTickPosX, entity.lastTickPosY, entity.lastTickPosZ, pos, TorchmasterConfig.GENERAL.dreadLampRadius.get());
+            && DistanceLogics.Cubic.isPositionInRange(pos.getX(), pos.getY(), pos.getZ(), this.pos, TorchmasterConfig.GENERAL.dreadLampRadius.get());
     }
 
     @Override

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/megatorch/MegatorchEntityBlockingLight.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/megatorch/MegatorchEntityBlockingLight.java
@@ -24,10 +24,10 @@ public class MegatorchEntityBlockingLight implements IEntityBlockingLight
     }
 
     @Override
-    public boolean shouldBlockEntity(Entity entity)
+    public boolean shouldBlockEntity(Entity entity, BlockPos pos)
     {
         return Torchmaster.MegaTorchFilterRegistry.containsEntity(entity.getType().getRegistryName())
-            && DistanceLogics.Cubic.isPositionInRange(entity.lastTickPosX, entity.lastTickPosY, entity.lastTickPosZ, pos, TorchmasterConfig.GENERAL.megaTorchRadius.get());
+            && DistanceLogics.Cubic.isPositionInRange(pos.getX(), pos.getY(), pos.getZ(), this.pos, TorchmasterConfig.GENERAL.megaTorchRadius.get());
     }
 
     @Override


### PR DESCRIPTION
# The Problem

Phantoms don't actually show the correct location of where they are. Applying [debug messages](https://github.com/Xalcon/TorchMaster/compare/mc/1.16...shroomdog27:debug) to DistanceLogics.Cubic shows that posX, poxY, and posZ are actually all zero when the entity type in question is a phantom.

Some output before this patch

```
[20:53:12] [Server thread/INFO] [ne.xa.to.Torchmaster/]: minX = 55.0, posX = 0.0, minX <= posX = false
[20:53:12] [Server thread/INFO] [ne.xa.to.Torchmaster/]: maxX = 184.0, posX = 0.0, maxX >= posX = true
[20:53:12] [Server thread/INFO] [ne.xa.to.Torchmaster/]: minY = 8.0, posY = 0.0, minY <= posY = false
[20:53:12] [Server thread/INFO] [ne.xa.to.Torchmaster/]: maxY = 137.0, posY = 0.0, maxY >= posY = true
[20:53:12] [Server thread/INFO] [ne.xa.to.Torchmaster/]: minZ = -325.0, posZ = 0.0, minZ <= posZ = true
[20:53:12] [Server thread/INFO] [ne.xa.to.Torchmaster/]: maxZ = -196.0, posZ = 0.0, maxZ >= posZ = false
```


# The Cause

As a result of my Forge PR, `net.minecraft.world.spawner.PhantomSpawner`,

the relevant method portions look like this (lines 59 to 63 shown.)

```java
PhantomEntity phantomentity = EntityType.PHANTOM.create(p_230253_1_);
if(net.minecraftforge.common.ForgeHooks.canEntitySpawn(phantomentity, p_230253_1_, blockpos1.getX(), blockpos1.getY(), blockpos1.getZ(), null, SpawnReason.NATURAL) == -1) return 0;
phantomentity.moveTo(blockpos1, 0.0F, 0.0F);
ilivingentitydata = phantomentity.finalizeSpawn(p_230253_1_, difficultyinstance, SpawnReason.NATURAL, ilivingentitydata, (CompoundNBT)null);
p_230253_1_.addFreshEntityWithPassengers(phantomentity);
```

First, the phantom is created.

Second, the ForgeHook to fire the `LivingSpawnEvent.CheckSpawn` event.

Third, the phantom is moved to the desired `blockpos1`.

`blockpos1` is set on line 51 of the PhantomSpawner class.

```java
BlockPos blockpos1 = blockpos.above(20 + random.nextInt(15)).east(-10 + random.nextInt(21)).south(-10 + random.nextInt(21));
```

Finally, the phantom's spawn is finalized.

Note that the event is fired before the phantom is moved to `blockpos`!

# The Solution

I created a [Forge PR](https://github.com/MinecraftForge/MinecraftForge/pull/7722) to fix this issue on their end, but for now I wanted to open this PR here to make you aware of the issue as well.

Fetch the information given from the event and use THAT location instead of the entity's own (bad) location.

This corrects the behaviour of properly blocking phantoms, since the game is now checking where the phantoms are going to be, instead of where they currently are (which again, is 0, 0, 0).

Other entities are also still blocked, since their positions are also set properly in `net.minecraftforge.common.ForgeHooks.canEntitySpawn`.


Some output of the debug messages after this patch.
```
[20:59:16] [Server thread/DEBUG] [ne.xa.to.Torchmaster/]: minX = 55.0, posX = 113.0, minX <= posX = true
[20:59:16] [Server thread/DEBUG] [ne.xa.to.Torchmaster/]: maxX = 184.0, posX = 113.0, maxX >= posX = true
[20:59:16] [Server thread/DEBUG] [ne.xa.to.Torchmaster/]: minY = 8.0, posY = 99.0, minY <= posY = true
[20:59:16] [Server thread/DEBUG] [ne.xa.to.Torchmaster/]: maxY = 137.0, posY = 99.0, maxY >= posY = true
[20:59:16] [Server thread/DEBUG] [ne.xa.to.Torchmaster/]: minZ = -325.0, posZ = -259.0, minZ <= posZ = true
[20:59:16] [Server thread/DEBUG] [ne.xa.to.Torchmaster/]: maxZ = -196.0, posZ = -259.0, maxZ >= posZ = true
```

Using the BlockPos data from the event now correctly has phantoms (and other entities) be fixed.

Cats and Pillager Patrols are also fixed by this patch. (which were also PR'd by me. doh.)
