### PR TITLE
Move EventHandler higher up in the chain

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.daemon=false
 
 mod_version_major=2
 mod_version_minor=3
-mod_version_patch=7
+mod_version_patch=8
 mod_version_release_suffix=
 
 mcp_mappings_channel=snapshot

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/EntityBlockingEventHandler.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/EntityBlockingEventHandler.java
@@ -20,7 +20,7 @@ import net.xalcon.torchmaster.common.ModCaps;
 @Mod.EventBusSubscriber(modid = Torchmaster.MODID)
 public class EntityBlockingEventHandler
 {
-    @SubscribeEvent(priority = EventPriority.LOWEST)
+    @SubscribeEvent(priority = EventPriority.HIGHER)
     public static void onCheckSpawn(LivingSpawnEvent.CheckSpawn event) throws InterruptedException
     {
         boolean log = TorchmasterConfig.GENERAL.logSpawnChecks.get();


### PR DESCRIPTION
This will improve the compatibility with Apotheosis as discussed in #150.
Additional changes are required to re-add support for mods that ignore the event results `Deny` and `Allow` or that set the event result back to `Default`.