### PR TITLE
[1.19.2] Fixed FeralFlareLantern Model 

### DIFF
--- a/src/main/java/net/xalcon/torchmaster/common/blocks/FeralFlareLanternBlock.java
+++ b/src/main/java/net/xalcon/torchmaster/common/blocks/FeralFlareLanternBlock.java
@@ -25,8 +25,6 @@ import javax.annotation.Nullable;
 public class FeralFlareLanternBlock extends DirectionalBlock implements EntityBlock {
 
     protected static final VoxelShape SHAPE_VERTICAL = Block.box(4.0D, 2.0D, 4.0D, 12.0D, 14.0D, 12.0D);
-    protected static final VoxelShape SHAPE_HORIZONTAL = Block.box(2.0D, 4.0D, 4.0D, 14.0D, 12.0D, 12.0D);
-    protected static final VoxelShape SHAPE_HORIZONTAL_90 = Block.box(4.0D, 4.0D, 2.0D, 12.0D, 12.0D, 14.0D);
 
     public FeralFlareLanternBlock(Properties properties) {
         super(properties);
@@ -35,11 +33,7 @@ public class FeralFlareLanternBlock extends DirectionalBlock implements EntityBl
 
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
-        return switch (state.getValue(FACING).getAxis()) {
-            case X -> SHAPE_HORIZONTAL;
-            case Y -> SHAPE_VERTICAL;
-            case Z -> SHAPE_HORIZONTAL_90;
-        };
+        return SHAPE_VERTICAL;
     }
 
     @Override

--- a/src/main/java/net/xalcon/torchmaster/common/blocks/FeralFlareLanternBlock.java
+++ b/src/main/java/net/xalcon/torchmaster/common/blocks/FeralFlareLanternBlock.java
@@ -22,25 +22,29 @@ import net.xalcon.torchmaster.common.tiles.FeralFlareLanternTileEntity;
 
 import javax.annotation.Nullable;
 
-public class FeralFlareLanternBlock extends DirectionalBlock implements EntityBlock
-{
-    protected static final VoxelShape SHAPE = Block.box(4.0D, 0.0D, 4.0D, 12.0D, 16.0D, 12.0D);
+public class FeralFlareLanternBlock extends DirectionalBlock implements EntityBlock {
 
-    public FeralFlareLanternBlock(Properties properties)
-    {
+    protected static final VoxelShape SHAPE_VERTICAL = Block.box(4.0D, 2.0D, 4.0D, 12.0D, 14.0D, 12.0D);
+    protected static final VoxelShape SHAPE_HORIZONTAL = Block.box(2.0D, 4.0D, 4.0D, 14.0D, 12.0D, 12.0D);
+    protected static final VoxelShape SHAPE_HORIZONTAL_90 = Block.box(4.0D, 4.0D, 2.0D, 12.0D, 12.0D, 14.0D);
+
+    public FeralFlareLanternBlock(Properties properties) {
         super(properties);
-        this.registerDefaultState(this.getStateDefinition().any().setValue(FACING, Direction.SOUTH));
+        this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.SOUTH));
     }
 
     @Override
-    public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context)
-    {
-        return SHAPE;
+    public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+        return switch (state.getValue(FACING).getAxis()) {
+            case X -> SHAPE_HORIZONTAL;
+            case Y -> SHAPE_VERTICAL;
+            case Z -> SHAPE_HORIZONTAL_90;
+        };
     }
 
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
-        return this.defaultBlockState().setValue(FACING, context.getNearestLookingDirection());
+        return this.defaultBlockState().setValue(FACING, context.getClickedFace().getOpposite());
     }
 
     @Override
@@ -49,8 +53,7 @@ public class FeralFlareLanternBlock extends DirectionalBlock implements EntityBl
     }
 
     @Override
-    public BlockState rotate(BlockState state, Rotation rot)
-    {
+    public BlockState rotate(BlockState state, Rotation rot) {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
@@ -62,36 +65,32 @@ public class FeralFlareLanternBlock extends DirectionalBlock implements EntityBl
     @Override
     public void onRemove(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean moving) {
         var te = world.getBlockEntity(pos);
-        if(te instanceof FeralFlareLanternTileEntity)
+        if (te instanceof FeralFlareLanternTileEntity)
             ((FeralFlareLanternTileEntity) te).removeChildLights();
 
         super.onRemove(state, world, pos, oldState, moving);
     }
 
 
-
     @Override
-    public void destroy(LevelAccessor level, BlockPos pos, BlockState state)
-    {
+    public void destroy(LevelAccessor level, BlockPos pos, BlockState state) {
         var te = level.getBlockEntity(pos);
-        if(te instanceof FeralFlareLanternTileEntity)
+        if (te instanceof FeralFlareLanternTileEntity)
             ((FeralFlareLanternTileEntity) te).removeChildLights();
         super.destroy(level, pos, state);
     }
 
     @Override
-    public void playerDestroy(Level level, Player player, BlockPos pos, BlockState state, @org.jetbrains.annotations.Nullable BlockEntity te, ItemStack itemStack)
-    {
-        if(te instanceof FeralFlareLanternTileEntity)
+    public void playerDestroy(Level level, Player player, BlockPos pos, BlockState state, @org.jetbrains.annotations.Nullable BlockEntity te, ItemStack itemStack) {
+        if (te instanceof FeralFlareLanternTileEntity)
             ((FeralFlareLanternTileEntity) te).removeChildLights();
         super.playerDestroy(level, player, pos, state, te, itemStack);
     }
 
     @Override
-    public void wasExploded(Level level, BlockPos pos, Explosion explosion)
-    {
+    public void wasExploded(Level level, BlockPos pos, Explosion explosion) {
         var te = level.getBlockEntity(pos);
-        if(te instanceof FeralFlareLanternTileEntity)
+        if (te instanceof FeralFlareLanternTileEntity)
             ((FeralFlareLanternTileEntity) te).removeChildLights();
         super.wasExploded(level, pos, explosion);
     }
@@ -107,7 +106,6 @@ public class FeralFlareLanternBlock extends DirectionalBlock implements EntityBl
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
         return type == ModBlocks.tileFeralFlareLantern.get() ? FeralFlareLanternTileEntity::dispatchTickBlockEntity : null;
     }
-
 
 
     //@Override

--- a/src/main/resources/assets/torchmaster/blockstates/feral_flare_lantern.json
+++ b/src/main/resources/assets/torchmaster/blockstates/feral_flare_lantern.json
@@ -1,10 +1,10 @@
 {
   "variants": {
-    "facing=south": { "model": "torchmaster:block/feral_flare_lantern" },
-    "facing=north": { "model": "torchmaster:block/feral_flare_lantern" },
-    "facing=east": { "model": "torchmaster:block/feral_flare_lantern" },
-    "facing=west": { "model": "torchmaster:block/feral_flare_lantern" },
-    "facing=up": { "model": "torchmaster:block/feral_flare_lantern" },
-    "facing=down": { "model": "torchmaster:block/feral_flare_lantern" }
+    "facing=south": { "model": "torchmaster:block/feral_flare_lantern_stand", "x": 90 },
+    "facing=north": { "model": "torchmaster:block/feral_flare_lantern_stand", "x": 270 },
+    "facing=east": { "model": "torchmaster:block/feral_flare_lantern_stand", "x": 270, "y": 90 },
+    "facing=west": { "model": "torchmaster:block/feral_flare_lantern_stand", "x": 90, "y": 90 },
+    "facing=up": { "model": "torchmaster:block/feral_flare_lantern_stand", "x": 180 },
+    "facing=down": { "model": "torchmaster:block/feral_flare_lantern_stand" }
   }
 }

--- a/src/main/resources/assets/torchmaster/blockstates/feral_flare_lantern.json
+++ b/src/main/resources/assets/torchmaster/blockstates/feral_flare_lantern.json
@@ -1,10 +1,64 @@
 {
-  "variants": {
-    "facing=south": { "model": "torchmaster:block/feral_flare_lantern_stand", "x": 90 },
-    "facing=north": { "model": "torchmaster:block/feral_flare_lantern_stand", "x": 270 },
-    "facing=east": { "model": "torchmaster:block/feral_flare_lantern_stand", "x": 270, "y": 90 },
-    "facing=west": { "model": "torchmaster:block/feral_flare_lantern_stand", "x": 90, "y": 90 },
-    "facing=up": { "model": "torchmaster:block/feral_flare_lantern_stand", "x": 180 },
-    "facing=down": { "model": "torchmaster:block/feral_flare_lantern_stand" }
-  }
+  "multipart": [
+    {
+      "apply": {
+        "model": "torchmaster:block/feral_flare_lantern"
+      }
+    },
+    {
+      "apply": {
+        "model": "torchmaster:block/feral_flare_lantern_stand",
+        "x": 90
+      },
+      "when": {
+        "facing": "south"
+      }
+    },
+    {
+      "apply": {
+        "model": "torchmaster:block/feral_flare_lantern_stand",
+        "x": 270
+      },
+      "when": {
+        "facing": "north"
+      }
+    },
+    {
+      "apply": {
+        "model": "torchmaster:block/feral_flare_lantern_stand",
+        "x": 270,
+        "y": 90
+      },
+      "when": {
+        "facing": "east"
+      }
+    },
+    {
+      "apply": {
+        "model": "torchmaster:block/feral_flare_lantern_stand",
+        "x": 90,
+        "y": 90
+      },
+      "when": {
+        "facing": "west"
+      }
+    },
+    {
+      "apply": {
+        "model": "torchmaster:block/feral_flare_lantern_stand",
+        "x": 180
+      },
+      "when": {
+        "facing": "up"
+      }
+    },
+    {
+      "apply": {
+        "model": "torchmaster:block/feral_flare_lantern_stand"
+      },
+      "when": {
+        "facing": "down"
+      }
+    }
+  ]
 }

--- a/src/main/resources/assets/torchmaster/models/block/feral_flare_lantern_stand.json
+++ b/src/main/resources/assets/torchmaster/models/block/feral_flare_lantern_stand.json
@@ -7,19 +7,6 @@
 	"parent": "block/block",
 	"elements": [
 		{
-			"__comment": "lantern",
-			"from": [ 4, 2, 4 ],
-			"to": [ 12, 14, 12 ],
-			"faces": {
-				"down": { "uv": [ 8, 0, 16, 8 ], "texture": "#tex" },
-				"up": { "uv": [ 8, 0, 16, 8 ], "texture": "#tex" },
-				"north": { "uv": [ 0, 0, 8, 12 ], "texture": "#tex" },
-				"south": { "uv": [ 0, 0, 8, 12 ], "texture": "#tex" },
-				"west": { "uv": [ 0, 0, 8, 12 ], "texture": "#tex" },
-				"east": { "uv": [ 0, 0, 8, 12 ], "texture": "#tex" }
-			}
-		},
-		{
 			"__comment": "stand",
 			"from": [ 6, 0, 6 ],
 			"to": [ 10, 1, 10 ],

--- a/src/main/resources/assets/torchmaster/models/block/feral_flare_lantern_stand.json
+++ b/src/main/resources/assets/torchmaster/models/block/feral_flare_lantern_stand.json
@@ -5,7 +5,20 @@
 		"particle": "torchmaster:block/feral_flare_lantern"
 	},
 	"parent": "block/block",
-	"elements": [ 	 
+	"elements": [
+		{
+			"__comment": "lantern",
+			"from": [ 4, 2, 4 ],
+			"to": [ 12, 14, 12 ],
+			"faces": {
+				"down": { "uv": [ 8, 0, 16, 8 ], "texture": "#tex" },
+				"up": { "uv": [ 8, 0, 16, 8 ], "texture": "#tex" },
+				"north": { "uv": [ 0, 0, 8, 12 ], "texture": "#tex" },
+				"south": { "uv": [ 0, 0, 8, 12 ], "texture": "#tex" },
+				"west": { "uv": [ 0, 0, 8, 12 ], "texture": "#tex" },
+				"east": { "uv": [ 0, 0, 8, 12 ], "texture": "#tex" }
+			}
+		},
 		{
 			"__comment": "stand",
 			"from": [ 6, 0, 6 ],


### PR DESCRIPTION
This PR provides fix for `FeralFlareLantern` including:

- model render fix for lantern's stand;
- placement fix, now `Direction` is set based on clicked face of the block; 
- code formatting for better readability and unification.

NOTE: Version `1.19.2` was chosen because I actively play on it, but I'm sure this will help you fix the issue on other versions as well.
Feel free to request any changes if needed.
Thanks!
Quick Demo (old, see below for updated version):
![image](https://github.com/user-attachments/assets/8b30526c-dcf1-4988-b546-14fb1e1063c5)
