### PR TITLE
Fix invisible light blockstate warning

### DIFF
--- a/common/src/main/resources/assets/torchmaster/blockstates/invisible_light.json
+++ b/common/src/main/resources/assets/torchmaster/blockstates/invisible_light.json
@@ -1,1 +1,7 @@
-{}
+{
+  "variants": {
+    "": {
+      "model": "torchmaster:block/invisible_light"
+    }
+  }
+}

--- a/common/src/main/resources/assets/torchmaster/models/block/invisible_light.json
+++ b/common/src/main/resources/assets/torchmaster/models/block/invisible_light.json
@@ -1,0 +1,6 @@
+{
+  "textures": {
+    "particle": "minecraft:item/light_15"
+  },
+  "elements": []
+}


### PR DESCRIPTION
This fixes the invisible light blockstate being an empty JSON object.

On 1.21.1 the client logs this during resource reload:

[Worker-ResourceReload-10/WARN] [net.minecraft.client.resources.model.BlockStateModelLoader/]: Exception loading blockstate definition: 'torchmaster:blockstates/invisible_light.json' missing model for variant: 'torchmaster:invisible_light#'

The block is still invisible; this just gives it a valid empty model and uses the vanilla light particle texture as a fallback.