### PR TITLE
feat: Added Mega Torch monster spawn skip mode with diamond base

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 buildscript {
     repositories {
         maven { url = 'https://files.minecraftforge.net/maven' }
+        maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
         jcenter()
         mavenCentral()
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
+        classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
     }
 }
 
@@ -13,6 +15,7 @@ apply plugin: 'net.minecraftforge.gradle'
 // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
+apply plugin: 'org.spongepowered.mixin'
 
 version = "${mod_version_major}.${mod_version_minor}.${mod_version_patch}${mod_version_release_suffix}"
 group = 'net.xalcon.torchmaster' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
@@ -92,7 +95,13 @@ dependencies {
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft "net.minecraftforge:forge:${forge_version}"
+    compileOnly 'org.spongepowered:mixin:0.8.5'
+    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 
+}
+
+mixin {
+    add sourceSets.main, "torchmaster.refmap.json"
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..
@@ -105,7 +114,8 @@ jar {
                 "Implementation-Title": project.name,
                 "Implementation-Version": "${version}",
                 "Implementation-Vendor" :"xalcon",
-                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
+                "MixinConfigs": "torchmaster.mixins.json"
         ])
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 mod_version_major=2
-mod_version_minor=3
-mod_version_patch=8
+mod_version_minor=4
+mod_version_patch=0
 mod_version_release_suffix=
 
 mcp_mappings_channel=snapshot

--- a/src/main/java/net/xalcon/torchmaster/common/ModBlocks.java
+++ b/src/main/java/net/xalcon/torchmaster/common/ModBlocks.java
@@ -15,6 +15,7 @@ import net.minecraftforge.registries.ObjectHolder;
 import net.xalcon.torchmaster.Torchmaster;
 import net.xalcon.torchmaster.common.blocks.EntityBlockingLightBlock;
 import net.xalcon.torchmaster.common.blocks.FeralFlareLanternBlock;
+import net.xalcon.torchmaster.common.blocks.MegaTorchBlock;
 import net.xalcon.torchmaster.common.items.TMItemBlock;
 import net.xalcon.torchmaster.common.logic.entityblocking.dreadlamp.DreadLampEntityBlockingLight;
 import net.xalcon.torchmaster.common.logic.entityblocking.megatorch.MegatorchEntityBlockingLight;
@@ -28,7 +29,7 @@ import static net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 public final class ModBlocks
 {
     @ObjectHolder("megatorch")
-    public static EntityBlockingLightBlock blockMegaTorch;
+    public static MegaTorchBlock blockMegaTorch;
     @ObjectHolder("megatorch")
     public static TMItemBlock itemMegaTorch;
 
@@ -56,12 +57,12 @@ public final class ModBlocks
             IForgeRegistry<Block> registry = event.getRegistry();
 
             /* Mega Torch */
-            blockMegaTorch = new EntityBlockingLightBlock(Block.Properties
+            blockMegaTorch = new MegaTorchBlock(Block.Properties
                     .create(Material.WOOD)
                     .hardnessAndResistance(1.0f, 1.0f)
                     .setLightLevel(blockState -> 15),
                 pos -> "MT_" +pos.getX() + "_" + pos.getY() + "_" + pos.getZ(),
-                MegatorchEntityBlockingLight::new, 1.0f, MegatorchEntityBlockingLight.SHAPE);
+                1.0f, MegatorchEntityBlockingLight.SHAPE);
             blockMegaTorch.setRegistryName("megatorch");
             registry.register(blockMegaTorch);
 

--- a/src/main/java/net/xalcon/torchmaster/common/blocks/EntityBlockingLightBlock.java
+++ b/src/main/java/net/xalcon/torchmaster/common/blocks/EntityBlockingLightBlock.java
@@ -12,7 +12,6 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.xalcon.torchmaster.common.ModCaps;
 import net.xalcon.torchmaster.common.logic.entityblocking.IEntityBlockingLight;
-import net.xalcon.torchmaster.common.logic.entityblocking.megatorch.MegatorchEntityBlockingLight;
 
 import java.util.Random;
 import java.util.function.Function;
@@ -21,8 +20,8 @@ public class EntityBlockingLightBlock extends Block
 {
     protected static final VoxelShape SHAPE = Block.makeCuboidShape(6.0D, 0.0D, 6.0D, 10.0D, 16.0D, 10.0D);
 
-    private Function<BlockPos, String> keyFactory;
-    private Function<BlockPos, IEntityBlockingLight> lightFactory;
+    protected Function<BlockPos, String> keyFactory;
+    protected Function<BlockPos, IEntityBlockingLight> lightFactory;
     private float flameOffsetY;
     private final VoxelShape shape;
 
@@ -59,8 +58,24 @@ public class EntityBlockingLightBlock extends Block
         .ifPresent(reg ->
         {
             //String lightKey = pos.getX() + "_" + pos.getY() + "_" + pos.getZ();
-            reg.registerLight(this.keyFactory.apply(pos), this.lightFactory.apply(pos));
+            reg.registerLight(this.getLightKey(pos), this.createLight(state, pos));
         });
+    }
+
+    protected String getLightKey(BlockPos pos)
+    {
+        return this.keyFactory.apply(pos);
+    }
+
+    protected IEntityBlockingLight createLight(BlockState state, BlockPos pos)
+    {
+        return this.lightFactory.apply(pos);
+    }
+
+    protected void updateLight(World world, BlockState state, BlockPos pos)
+    {
+        world.getCapability(ModCaps.TEB_REGISTRY)
+            .ifPresent(reg -> reg.registerLight(this.getLightKey(pos), this.createLight(state, pos)));
     }
 
     public boolean propagatesSkylightDown(BlockState state, IBlockReader reader, BlockPos pos) {
@@ -69,14 +84,17 @@ public class EntityBlockingLightBlock extends Block
 
 
     @Override
-    public void onReplaced(BlockState state, World world, BlockPos pos, BlockState oldState, boolean moving)
+    public void onReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moving)
     {
-        world.getCapability(ModCaps.TEB_REGISTRY)
-        .ifPresent(reg ->
+        if(state.getBlock() != newState.getBlock())
         {
-            //String lightKey = pos.getX() + "_" + pos.getY() + "_" + pos.getZ();
-            reg.unregisterLight(this.keyFactory.apply(pos));
-        });
-        super.onReplaced(state, world, pos, oldState, moving);
+            world.getCapability(ModCaps.TEB_REGISTRY)
+            .ifPresent(reg ->
+            {
+                //String lightKey = pos.getX() + "_" + pos.getY() + "_" + pos.getZ();
+                reg.unregisterLight(this.getLightKey(pos));
+            });
+        }
+        super.onReplaced(state, world, pos, newState, moving);
     }
 }

--- a/src/main/java/net/xalcon/torchmaster/common/blocks/MegaTorchBlock.java
+++ b/src/main/java/net/xalcon/torchmaster/common/blocks/MegaTorchBlock.java
@@ -1,0 +1,83 @@
+package net.xalcon.torchmaster.common.blocks;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.state.BooleanProperty;
+import net.minecraft.state.StateContainer;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.world.World;
+import net.xalcon.torchmaster.common.logic.entityblocking.IEntityBlockingLight;
+import net.xalcon.torchmaster.common.logic.entityblocking.megatorch.MegatorchEntityBlockingLight;
+
+import java.util.function.Function;
+
+public class MegaTorchBlock extends EntityBlockingLightBlock
+{
+    public static final BooleanProperty DIAMOND_BASE = BooleanProperty.create("diamond_base");
+
+    public MegaTorchBlock(Properties properties, Function<BlockPos, String> keyFactory, float flameOffsetY, VoxelShape shape)
+    {
+        super(properties, keyFactory, MegatorchEntityBlockingLight::new, flameOffsetY, shape);
+        this.setDefaultState(this.stateContainer.getBaseState().with(DIAMOND_BASE, false));
+    }
+
+    @Override
+    protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder)
+    {
+        builder.add(DIAMOND_BASE);
+    }
+
+    @Override
+    protected IEntityBlockingLight createLight(BlockState state, BlockPos pos)
+    {
+        return new MegatorchEntityBlockingLight(pos, state.get(DIAMOND_BASE));
+    }
+
+    @Override
+    public ActionResultType onBlockActivated(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockRayTraceResult hit)
+    {
+        if(hand != Hand.MAIN_HAND)
+            return ActionResultType.PASS;
+
+        boolean hasDiamondBase = state.get(DIAMOND_BASE);
+        ItemStack heldStack = player.getHeldItem(hand);
+
+        if(!hasDiamondBase && heldStack.getItem() == Blocks.DIAMOND_BLOCK.asItem())
+        {
+            if(!world.isRemote)
+            {
+                if(!player.abilities.isCreativeMode)
+                    heldStack.shrink(1);
+
+                BlockState newState = state.with(DIAMOND_BASE, true);
+                world.setBlockState(pos, newState, 3);
+                this.updateLight(world, newState, pos);
+            }
+            return ActionResultType.SUCCESS;
+        }
+
+        if(hasDiamondBase && player.isSneaking() && heldStack.isEmpty())
+        {
+            if(!world.isRemote)
+            {
+                BlockState newState = state.with(DIAMOND_BASE, false);
+                world.setBlockState(pos, newState, 3);
+                this.updateLight(world, newState, pos);
+
+                ItemStack diamondBlock = new ItemStack(Blocks.DIAMOND_BLOCK);
+                if(!player.addItemStackToInventory(diamondBlock))
+                    player.dropItem(diamondBlock, false);
+            }
+            return ActionResultType.SUCCESS;
+        }
+
+        return ActionResultType.PASS;
+    }
+}

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/IEntityBlockingLight.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/IEntityBlockingLight.java
@@ -1,12 +1,29 @@
 package net.xalcon.torchmaster.common.logic.entityblocking;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public interface IEntityBlockingLight
 {
     boolean shouldBlockEntity(Entity entity, BlockPos pos);
+
+    default boolean shouldBlockEntity(EntityType<?> entityType, BlockPos pos)
+    {
+        return false;
+    }
+
+    default boolean shouldBlockNaturalSpawnPosition(BlockPos pos)
+    {
+        return false;
+    }
+
+    default boolean shouldBlockNaturalSpawnChunk(int chunkX, int chunkZ)
+    {
+        return false;
+    }
+
     String getLightSerializerKey();
 
     String getName();

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/ITEBLightRegistry.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/ITEBLightRegistry.java
@@ -1,6 +1,7 @@
 package net.xalcon.torchmaster.common.logic.entityblocking;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
@@ -11,6 +12,9 @@ import net.xalcon.torchmaster.common.commands.TorchInfo;
 public interface ITEBLightRegistry extends INBTSerializable<CompoundNBT>
 {
     boolean shouldBlockEntity(Entity entity, BlockPos pos);
+    boolean shouldBlockEntity(EntityType<?> entityType, BlockPos pos);
+    boolean shouldBlockNaturalSpawnPosition(BlockPos pos);
+    boolean shouldBlockNaturalSpawnChunk(int chunkX, int chunkZ);
 
     /**
      * Warning: The IEntityBlockingLight instance should not be directly attached to any chunk data!

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/LightsRegistryCapability.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/LightsRegistryCapability.java
@@ -1,6 +1,7 @@
 package net.xalcon.torchmaster.common.logic.entityblocking;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Tuple;
@@ -163,6 +164,42 @@ public class LightsRegistryCapability implements ICapabilityProvider, ICapabilit
             {
                 IEntityBlockingLight light = lightEntry.getValue();
                 if(light.shouldBlockEntity(entity, pos))
+                    return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean shouldBlockEntity(EntityType<?> entityType, BlockPos pos)
+        {
+            for(HashMap.Entry<String, IEntityBlockingLight> lightEntry : lights.entrySet())
+            {
+                IEntityBlockingLight light = lightEntry.getValue();
+                if(light.shouldBlockEntity(entityType, pos))
+                    return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean shouldBlockNaturalSpawnPosition(BlockPos pos)
+        {
+            for(HashMap.Entry<String, IEntityBlockingLight> lightEntry : lights.entrySet())
+            {
+                IEntityBlockingLight light = lightEntry.getValue();
+                if(light.shouldBlockNaturalSpawnPosition(pos))
+                    return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean shouldBlockNaturalSpawnChunk(int chunkX, int chunkZ)
+        {
+            for(HashMap.Entry<String, IEntityBlockingLight> lightEntry : lights.entrySet())
+            {
+                IEntityBlockingLight light = lightEntry.getValue();
+                if(light.shouldBlockNaturalSpawnChunk(chunkX, chunkZ))
                     return true;
             }
             return false;

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/NaturalSpawnBlocker.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/NaturalSpawnBlocker.java
@@ -1,0 +1,63 @@
+package net.xalcon.torchmaster.common.logic.entityblocking;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.server.ServerWorld;
+import net.xalcon.torchmaster.Torchmaster;
+import net.xalcon.torchmaster.TorchmasterConfig;
+import net.xalcon.torchmaster.common.ModCaps;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class NaturalSpawnBlocker
+{
+    private NaturalSpawnBlocker()
+    {
+    }
+
+    public static boolean shouldSkipNaturalSpawn(ServerWorld world, EntityType<?> entityType, BlockPos pos)
+    {
+        AtomicBoolean blocked = new AtomicBoolean(false);
+
+        world.getCapability(ModCaps.TEB_REGISTRY).ifPresent(reg -> blocked.set(reg.shouldBlockEntity(entityType, pos)));
+
+        boolean log = TorchmasterConfig.GENERAL.logSpawnChecks.get();
+        if(log && blocked.get())
+        {
+            Torchmaster.Log.debug("EarlyNaturalSpawn - Blocking natural spawn of {} at {}", entityType.getRegistryName(), pos);
+        }
+
+        return blocked.get();
+    }
+
+    public static boolean shouldSkipNaturalSpawnPosition(ServerWorld world, BlockPos pos)
+    {
+        AtomicBoolean blocked = new AtomicBoolean(false);
+
+        world.getCapability(ModCaps.TEB_REGISTRY).ifPresent(reg -> blocked.set(reg.shouldBlockNaturalSpawnPosition(pos)));
+
+        boolean log = TorchmasterConfig.GENERAL.logSpawnChecks.get();
+        if(log && blocked.get())
+        {
+            Torchmaster.Log.debug("EarlyNaturalSpawnPosition - Blocking natural spawn position at {}", pos);
+        }
+
+        return blocked.get();
+    }
+
+    public static boolean shouldSkipNaturalSpawnChunk(ServerWorld world, ChunkPos chunkPos)
+    {
+        AtomicBoolean blocked = new AtomicBoolean(false);
+
+        world.getCapability(ModCaps.TEB_REGISTRY).ifPresent(reg -> blocked.set(reg.shouldBlockNaturalSpawnChunk(chunkPos.x, chunkPos.z)));
+
+        boolean log = TorchmasterConfig.GENERAL.logSpawnChecks.get();
+        if(log && blocked.get())
+        {
+            Torchmaster.Log.debug("EarlyNaturalSpawnChunk - Blocking natural spawn chunk {}", chunkPos);
+        }
+
+        return blocked.get();
+    }
+}

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/megatorch/MegatorchEntityBlockingLight.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/megatorch/MegatorchEntityBlockingLight.java
@@ -2,6 +2,7 @@ package net.xalcon.torchmaster.common.logic.entityblocking.megatorch;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.VoxelShape;
@@ -17,17 +18,57 @@ public class MegatorchEntityBlockingLight implements IEntityBlockingLight
 {
     public static final VoxelShape SHAPE = Block.makeCuboidShape(6.0D, 0.0D, 6.0D, 10.0D, 16.0D, 10.0D);
     private BlockPos pos;
+    private boolean diamondBase;
 
     public MegatorchEntityBlockingLight(BlockPos pos)
     {
+        this(pos, false);
+    }
+
+    public MegatorchEntityBlockingLight(BlockPos pos, boolean diamondBase)
+    {
         this.pos = pos;
+        this.diamondBase = diamondBase;
     }
 
     @Override
     public boolean shouldBlockEntity(Entity entity, BlockPos pos)
     {
+        if(this.diamondBase)
+            return false;
+
         return Torchmaster.MegaTorchFilterRegistry.containsEntity(entity.getType().getRegistryName())
             && DistanceLogics.Cubic.isPositionInRange(pos.getX(), pos.getY(), pos.getZ(), this.pos, TorchmasterConfig.GENERAL.megaTorchRadius.get());
+    }
+
+    @Override
+    public boolean shouldBlockEntity(EntityType<?> entityType, BlockPos pos)
+    {
+        if(this.diamondBase)
+            return false;
+
+        return Torchmaster.MegaTorchFilterRegistry.containsEntity(entityType.getRegistryName())
+            && DistanceLogics.Cubic.isPositionInRange(pos.getX(), pos.getY(), pos.getZ(), this.pos, TorchmasterConfig.GENERAL.megaTorchRadius.get());
+    }
+
+    @Override
+    public boolean shouldBlockNaturalSpawnPosition(BlockPos pos)
+    {
+        return this.diamondBase
+            && DistanceLogics.Cubic.isPositionInRange(pos.getX(), pos.getY(), pos.getZ(), this.pos, TorchmasterConfig.GENERAL.megaTorchRadius.get());
+    }
+
+    @Override
+    public boolean shouldBlockNaturalSpawnChunk(int chunkX, int chunkZ)
+    {
+        if(!this.diamondBase)
+            return false;
+
+        int chunkRadius = (TorchmasterConfig.GENERAL.megaTorchRadius.get() + 15) >> 4;
+        int torchChunkX = this.pos.getX() >> 4;
+        int torchChunkZ = this.pos.getZ() >> 4;
+        return Math.abs(chunkX - torchChunkX) <= chunkRadius
+            && Math.abs(chunkZ - torchChunkZ) <= chunkRadius;
     }
 
     @Override
@@ -59,5 +100,10 @@ public class MegatorchEntityBlockingLight implements IEntityBlockingLight
     public BlockPos getPos()
     {
         return pos;
+    }
+
+    public boolean hasDiamondBase()
+    {
+        return diamondBase;
     }
 }

--- a/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/megatorch/MegatorchSerializer.java
+++ b/src/main/java/net/xalcon/torchmaster/common/logic/entityblocking/megatorch/MegatorchSerializer.java
@@ -26,6 +26,7 @@ public class MegatorchSerializer implements ILightSerializer
 
         CompoundNBT nbt = new CompoundNBT();
         nbt.put("pos", NBTUtil.writeBlockPos(light.getPos()));
+        nbt.putBoolean("diamondBase", light.hasDiamondBase());
 
         return nbt;
     }
@@ -33,7 +34,7 @@ public class MegatorchSerializer implements ILightSerializer
     @Override
     public IEntityBlockingLight deserializeLight(String lightKey, CompoundNBT nbt)
     {
-        return new MegatorchEntityBlockingLight(NBTUtil.readBlockPos(nbt.getCompound("pos")));
+        return new MegatorchEntityBlockingLight(NBTUtil.readBlockPos(nbt.getCompound("pos")), nbt.getBoolean("diamondBase"));
     }
 
     @Override

--- a/src/main/java/net/xalcon/torchmaster/mixin/WorldEntitySpawnerMixin.java
+++ b/src/main/java/net/xalcon/torchmaster/mixin/WorldEntitySpawnerMixin.java
@@ -1,0 +1,86 @@
+package net.xalcon.torchmaster.mixin;
+
+import net.minecraft.entity.EntityClassification;
+import net.minecraft.entity.EntityType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.IChunk;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraft.world.spawner.WorldEntitySpawner;
+import net.xalcon.torchmaster.common.logic.entityblocking.NaturalSpawnBlocker;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(WorldEntitySpawner.class)
+public abstract class WorldEntitySpawnerMixin
+{
+    @Inject(method = "func_234979_a_", at = @At("HEAD"), cancellable = true)
+    private static void torchmaster$skipDiamondBaseBlockedNaturalSpawnChunk(
+        ServerWorld world,
+        Chunk chunk,
+        WorldEntitySpawner.EntityDensityManager densityManager,
+        boolean spawnHostiles,
+        boolean spawnPassives,
+        boolean spawnAnimals,
+        CallbackInfo ci)
+    {
+        if(NaturalSpawnBlocker.shouldSkipNaturalSpawnChunk(world, chunk.getPos()))
+            ci.cancel();
+    }
+
+    @Invoker("func_234978_a_")
+    private static boolean torchmaster$invokeCanSpawnAtPosition(ServerWorld world, IChunk chunk, BlockPos.Mutable pos, double distance)
+    {
+        throw new AssertionError();
+    }
+
+    @Redirect(
+        method = "func_234966_a_",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/spawner/WorldEntitySpawner;func_234978_a_(Lnet/minecraft/world/server/ServerWorld;Lnet/minecraft/world/chunk/IChunk;Lnet/minecraft/util/math/BlockPos$Mutable;D)Z"
+        )
+    )
+    private static boolean torchmaster$skipDiamondBaseBlockedNaturalSpawnPosition(
+        ServerWorld world,
+        IChunk chunk,
+        BlockPos.Mutable pos,
+        double distance,
+        EntityClassification classification,
+        ServerWorld originalWorld,
+        IChunk spawningChunk,
+        BlockPos initialPos,
+        WorldEntitySpawner.IDensityCheck densityCheck,
+        WorldEntitySpawner.IOnSpawnDensityAdder densityAdder)
+    {
+        return !NaturalSpawnBlocker.shouldSkipNaturalSpawnPosition(world, pos)
+            && torchmaster$invokeCanSpawnAtPosition(world, chunk, pos, distance);
+    }
+
+    @Redirect(
+        method = "func_234966_a_",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/spawner/WorldEntitySpawner$IDensityCheck;test(Lnet/minecraft/entity/EntityType;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/world/chunk/IChunk;)Z"
+        )
+    )
+    private static boolean torchmaster$skipMegaTorchBlockedNaturalSpawn(
+        WorldEntitySpawner.IDensityCheck densityCheck,
+        EntityType<?> entityType,
+        BlockPos pos,
+        IChunk chunk,
+        EntityClassification classification,
+        ServerWorld world,
+        IChunk spawningChunk,
+        BlockPos initialPos,
+        WorldEntitySpawner.IDensityCheck originalDensityCheck,
+        WorldEntitySpawner.IOnSpawnDensityAdder densityAdder)
+    {
+        return !NaturalSpawnBlocker.shouldSkipNaturalSpawn(world, entityType, pos)
+            && densityCheck.test(entityType, pos, chunk);
+    }
+}

--- a/src/main/resources/assets/torchmaster/blockstates/megatorch.json
+++ b/src/main/resources/assets/torchmaster/blockstates/megatorch.json
@@ -1,5 +1,6 @@
 {
   "variants": {
-    "": { "model": "torchmaster:block/megatorch" }
+    "diamond_base=false": { "model": "torchmaster:block/megatorch" },
+    "diamond_base=true": { "model": "torchmaster:block/megatorch_diamond_base" }
   }
 }

--- a/src/main/resources/assets/torchmaster/models/block/megatorch_diamond_base.json
+++ b/src/main/resources/assets/torchmaster/models/block/megatorch_diamond_base.json
@@ -1,0 +1,34 @@
+{
+  "textures": {
+    "torch": "torchmaster:block/megatorch",
+    "torch_top": "torchmaster:block/megatorch_top",
+    "base": "minecraft:block/diamond_block",
+    "particle": "minecraft:block/diamond_block"
+  },
+  "parent": "block/block",
+  "elements": [
+    {
+      "from": [ 4, 0, 4 ],
+      "to": [ 12, 2, 12 ],
+      "faces": {
+        "down": { "uv": [ 4, 4, 12, 12 ], "texture": "#base", "cullface": "down" },
+        "up": { "uv": [ 4, 4, 12, 12 ], "texture": "#base" },
+        "north": { "uv": [ 4, 14, 12, 16 ], "texture": "#base" },
+        "south": { "uv": [ 4, 14, 12, 16 ], "texture": "#base" },
+        "west": { "uv": [ 4, 14, 12, 16 ], "texture": "#base" },
+        "east": { "uv": [ 4, 14, 12, 16 ], "texture": "#base" }
+      }
+    },
+    {
+      "from": [ 6, 2, 6 ],
+      "to": [ 10, 16, 10 ],
+      "faces": {
+        "up": { "uv": [ 6, 6, 10, 10 ], "texture": "#torch_top", "cullface": "up" },
+        "north": { "uv": [ 6, 2, 10, 16 ], "texture": "#torch" },
+        "south": { "uv": [ 6, 2, 10, 16 ], "texture": "#torch" },
+        "west": { "uv": [ 6, 2, 10, 16 ], "texture": "#torch" },
+        "east": { "uv": [ 6, 2, 10, 16 ], "texture": "#torch" }
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/torchmaster/loot_tables/blocks/megatorch.json
+++ b/src/main/resources/data/torchmaster/loot_tables/blocks/megatorch.json
@@ -14,6 +14,27 @@
           "condition": "minecraft:survives_explosion"
         }
       ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:diamond_block"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "torchmaster:megatorch",
+          "properties": {
+            "diamond_base": "true"
+          }
+        }
+      ]
     }
   ]
 }

--- a/src/main/resources/torchmaster.mixins.json
+++ b/src/main/resources/torchmaster.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "net.xalcon.torchmaster.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "refmap": "torchmaster.refmap.json",
+  "mixins": [
+    "WorldEntitySpawnerMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
Added Mixin to exclude chunks and candidate locations covered by Mega Torch diamond bases earlier in the natural monster spawning process, and added right-click support for placing/removing diamond bricks, models, and drops.