### PR TITLE
Feature/mc/1.21.1/volume renderer

### DIFF
--- a/common/src/main/java/net/xalcon/torchmaster/blocks/EntityBlockingLightBlock.java
+++ b/common/src/main/java/net/xalcon/torchmaster/blocks/EntityBlockingLightBlock.java
@@ -52,13 +52,13 @@ public class EntityBlockingLightBlock extends Block
 
             if(show)
             {
-                VolumeRendererOverlay.showVolumeAt(pPos, 64, color);
-                VolumeRendererOverlay.showLocationAt(pPos, color);
+                VolumeRendererOverlay.showVolumeAt(pLevel.dimension(), pPos, 64, color);
+                VolumeRendererOverlay.showLocationAt(pLevel.dimension(), pPos, color);
             }
             else
             {
-                VolumeRendererOverlay.removeVolumeAt(pPos);
-                VolumeRendererOverlay.removeLocationAt(pPos);
+                VolumeRendererOverlay.removeVolumeAt(pLevel.dimension(), pPos);
+                VolumeRendererOverlay.removeLocationAt(pLevel.dimension(), pPos);
             }
             return InteractionResult.SUCCESS;
         }

--- a/common/src/main/java/net/xalcon/torchmaster/blocks/EntityBlockingLightBlock.java
+++ b/common/src/main/java/net/xalcon/torchmaster/blocks/EntityBlockingLightBlock.java
@@ -2,14 +2,23 @@ package net.xalcon.torchmaster.blocks;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.DyeItem;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.xalcon.torchmaster.ModRegistry;
 import net.xalcon.torchmaster.Torchmaster;
+import net.xalcon.torchmaster.client.VolumeRendererOverlay;
 
 public class EntityBlockingLightBlock extends Block
 {
@@ -24,6 +33,37 @@ public class EntityBlockingLightBlock extends Block
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter blockGetter, BlockPos pos, CollisionContext ctx) {
         return lightType.Shape;
+    }
+
+    @Override
+    protected InteractionResult useWithoutItem(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, BlockHitResult pHitResult) {
+        if(pLevel.isClientSide)
+        {
+            var show = !pPlayer.isShiftKeyDown();
+            var color = 0xA0FF20;
+
+            var itemStack = pPlayer.getItemInHand(InteractionHand.MAIN_HAND);
+            if(itemStack.getItem() instanceof DyeItem item)
+            {
+                color = item.getDyeColor().getTextColor();
+            }
+
+            pPlayer.displayClientMessage(Component.translatable(show ? "torchmaster.torch_volume.on_show" : "torchmaster.torch_volume.on_hide"), true);
+
+            if(show)
+            {
+                VolumeRendererOverlay.showVolumeAt(pPos, 64, color);
+                VolumeRendererOverlay.showLocationAt(pPos, color);
+            }
+            else
+            {
+                VolumeRendererOverlay.removeVolumeAt(pPos);
+                VolumeRendererOverlay.removeLocationAt(pPos);
+            }
+            return InteractionResult.SUCCESS;
+        }
+
+        return super.useWithoutItem(pState, pLevel, pPos, pPlayer, pHitResult);
     }
 
     @Override

--- a/common/src/main/java/net/xalcon/torchmaster/blocks/EntityBlockingLightBlock.java
+++ b/common/src/main/java/net/xalcon/torchmaster/blocks/EntityBlockingLightBlock.java
@@ -1,5 +1,6 @@
 package net.xalcon.torchmaster.blocks;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
@@ -19,6 +20,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.xalcon.torchmaster.ModRegistry;
 import net.xalcon.torchmaster.Torchmaster;
 import net.xalcon.torchmaster.client.VolumeRendererOverlay;
+import net.xalcon.torchmaster.client.gui.EntityBlockingLightSettingsScreen;
+import net.xalcon.torchmaster.platform.Services;
 
 public class EntityBlockingLightBlock extends Block
 {
@@ -39,27 +42,10 @@ public class EntityBlockingLightBlock extends Block
     protected InteractionResult useWithoutItem(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, BlockHitResult pHitResult) {
         if(pLevel.isClientSide)
         {
-            var show = !pPlayer.isShiftKeyDown();
-            var color = 0xA0FF20;
-
-            var itemStack = pPlayer.getItemInHand(InteractionHand.MAIN_HAND);
-            if(itemStack.getItem() instanceof DyeItem item)
-            {
-                color = item.getDyeColor().getTextColor();
-            }
-
-            pPlayer.displayClientMessage(Component.translatable(show ? "torchmaster.torch_volume.on_show" : "torchmaster.torch_volume.on_hide"), true);
-
-            if(show)
-            {
-                VolumeRendererOverlay.showVolumeAt(pLevel.dimension(), pPos, 64, color);
-                VolumeRendererOverlay.showLocationAt(pLevel.dimension(), pPos, color);
-            }
-            else
-            {
-                VolumeRendererOverlay.removeVolumeAt(pLevel.dimension(), pPos);
-                VolumeRendererOverlay.removeLocationAt(pLevel.dimension(), pPos);
-            }
+            int range = lightType == LightType.DreadLamp ? Services.PLATFORM.getConfig().getDreadLampRadius()
+                    : lightType == LightType.MegaTorch ? Services.PLATFORM.getConfig().getMegaTorchRadius()
+                    : 0;
+            Minecraft.getInstance().setScreen(new EntityBlockingLightSettingsScreen(pPos, range));
             return InteractionResult.SUCCESS;
         }
 

--- a/common/src/main/java/net/xalcon/torchmaster/client/VolumeRendererOverlay.java
+++ b/common/src/main/java/net/xalcon/torchmaster/client/VolumeRendererOverlay.java
@@ -9,8 +9,10 @@ import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.core.Vec3i;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Tuple;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.phys.Vec3;
 
@@ -19,6 +21,15 @@ import java.util.Map;
 
 public class VolumeRendererOverlay {
     private static final ResourceLocation FORCEFIELD_LOCATION = ResourceLocation.fromNamespaceAndPath("minecraft", "textures/misc/forcefield.png");
+
+    private record LightKey(ResourceLocation dimension, Vec3i pos) {
+        public LightKey(ResourceKey<Level> dimension, Vec3i pos) {
+            this(dimension.location(), pos);
+        }
+    }
+
+    private static final Map<LightKey, Tuple<Integer, Integer>> volumeLights = new HashMap<>();
+    private static final Map<LightKey, Integer> locationLights = new HashMap<>();
 
     private static BoundingBox createVolume(Vec3i pos, int halfRange)
     {
@@ -214,27 +225,24 @@ public class VolumeRendererOverlay {
         RenderSystem.depthMask(true);
     }
 
-    private static final Map<Vec3i, Tuple<Integer, Integer>> volumeLights = new HashMap<>();
-    private static final Map<Vec3i, Integer> locationLights = new HashMap<>();
-
-    public static void showVolumeAt(Vec3i pos, int range, int color)
+    public static void showVolumeAt(ResourceKey<Level> dimension, Vec3i pos, int range, int color)
     {
-        volumeLights.put(pos, new Tuple<>(range, color));
+        volumeLights.put(new LightKey(dimension, pos), new Tuple<>(range, color));
     }
 
-    public static void removeVolumeAt(Vec3i pos)
+    public static void removeVolumeAt(ResourceKey<Level> dimension, Vec3i pos)
     {
-        volumeLights.remove(pos);
+        volumeLights.remove(new LightKey(dimension, pos));
     }
 
-    public static void showLocationAt(Vec3i pos, int color)
+    public static void showLocationAt(ResourceKey<Level> dimension, Vec3i pos, int color)
     {
-        locationLights.put(pos, color);
+        locationLights.put(new LightKey(dimension, pos), color);
     }
 
-    public static void removeLocationAt(Vec3i pos)
+    public static void removeLocationAt(ResourceKey<Level> dimension, Vec3i pos)
     {
-        locationLights.remove(pos);
+        locationLights.remove(new LightKey(dimension, pos));
     }
 
     public static void clearAll()
@@ -243,17 +251,21 @@ public class VolumeRendererOverlay {
         locationLights.clear();
     }
 
-    public static void onRenderLevel(Camera camera) {
+    public static void onRenderLevel(ResourceKey<Level> dimension, Camera camera) {
         for (var light : volumeLights.entrySet())
         {
-            renderLightVolume(light.getKey(), light.getValue().getA(), camera, light.getValue().getB());
-            renderWireframeCube(light.getKey(), light.getValue().getA(), light.getValue().getB(), camera);
+            var key = light.getKey();
+            if(!dimension.location().equals(key.dimension)) continue; // Dont render stuff from different dimensions
+            renderLightVolume(key.pos, light.getValue().getA(), camera, light.getValue().getB());
+            renderWireframeCube(key.pos, light.getValue().getA(), light.getValue().getB(), camera);
         }
 
         for (var light : locationLights.entrySet())
         {
-            renderTorchLocation(light.getKey(), light.getValue(), camera);
-            renderWireframeCube(light.getKey(), 0, light.getValue(), camera);
+            var key = light.getKey();
+            if(!dimension.location().equals(key.dimension)) continue; // Dont render stuff from different dimensions
+            renderTorchLocation(key.pos, light.getValue(), camera);
+            renderWireframeCube(key.pos, 0, light.getValue(), camera);
         }
     }
 

--- a/common/src/main/java/net/xalcon/torchmaster/client/VolumeRendererOverlay.java
+++ b/common/src/main/java/net/xalcon/torchmaster/client/VolumeRendererOverlay.java
@@ -1,0 +1,347 @@
+package net.xalcon.torchmaster.client;
+
+import com.mojang.authlib.minecraft.client.MinecraftClient;
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.*;
+import net.minecraft.Util;
+import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.core.Vec3i;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Tuple;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class VolumeRendererOverlay {
+    private static final ResourceLocation FORCEFIELD_LOCATION = ResourceLocation.fromNamespaceAndPath("minecraft", "textures/misc/forcefield.png");
+
+    private static BoundingBox createVolume(Vec3i pos, int halfRange)
+    {
+        var min = pos.offset(-halfRange, -halfRange, -halfRange);
+        var max = pos.offset(halfRange + 1, halfRange + 1, halfRange + 1);
+        return BoundingBox.fromCorners(min, max);
+    }
+
+    private static void renderWireframeCube(Vec3i pos, int torchRange, int color, Camera cam)
+    {
+
+        var mc = Minecraft.getInstance();
+        var blockRenderDistance = mc.options.getEffectiveRenderDistance() * 16;
+        var torchVol = createVolume(pos, torchRange);
+        var playerVolume = createVolume(cam.getBlockPosition(), blockRenderDistance);
+        if(!playerVolume.intersects(torchVol)) return;
+
+        var camX = cam.getPosition().x;
+        var camZ = cam.getPosition().z;
+        var camY = cam.getPosition().y;
+
+        RenderSystem.enableBlend();
+        RenderSystem.enableDepthTest();
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ZERO, GlStateManager.DestFactor.ONE);
+        RenderSystem.depthMask(Minecraft.useShaderTransparency());
+        // Set color multiplier
+        float red = (float)(color >> 16 & 255) / 255.0F;
+        float green = (float)(color >> 8 & 255) / 255.0F;
+        float blue = (float)(color & 255) / 255.0F;
+        RenderSystem.setShaderColor(red, green, blue, 1f);
+        RenderSystem.setShader(GameRenderer::getPositionShader);
+        // Offset is used to work around z-fighting issues
+        RenderSystem.polygonOffset(-3.0F, -3.0F);
+        RenderSystem.enablePolygonOffset();
+        // Render both sides
+        RenderSystem.disableCull();
+
+        BufferBuilder bufferbuilder = Tesselator.getInstance().begin(VertexFormat.Mode.DEBUG_LINES, DefaultVertexFormat.POSITION_COLOR);
+
+        var vMinX = (float)(torchVol.minX() - camX);
+        var vMaxX = (float)(torchVol.maxX() - camX);
+        var vMinY = (float)(torchVol.minY() - camY);
+        var vMaxY = (float)(torchVol.maxY() - camY);
+        var vMinZ = (float)(torchVol.minZ() - camZ);
+        var vMaxZ = (float)(torchVol.maxZ() - camZ);
+
+        // We need to set the base color for the lines to white so the multiplier for shader color can work properly.
+        // And yea, it's pretty hacky, whatever.
+        color = 0xFFFFFFFF;
+
+        // Bottom face
+        bufferbuilder.addVertex(vMinX, vMinY, vMinZ).setColor(color);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMinZ).setColor(color);
+
+        bufferbuilder.addVertex(vMaxX, vMinY, vMinZ).setColor(color);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMaxZ).setColor(color);
+
+        bufferbuilder.addVertex(vMaxX, vMinY, vMaxZ).setColor(color);
+        bufferbuilder.addVertex(vMinX, vMinY, vMaxZ).setColor(color);
+
+        bufferbuilder.addVertex(vMinX, vMinY, vMaxZ).setColor(color);
+        bufferbuilder.addVertex(vMinX, vMinY, vMinZ).setColor(color);
+
+        // Top face
+        bufferbuilder.addVertex(vMinX, vMaxY, vMinZ).setColor(color);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMinZ).setColor(color);
+
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMinZ).setColor(color);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMaxZ).setColor(color);
+
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMaxZ).setColor(color);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMaxZ).setColor(color);
+
+        bufferbuilder.addVertex(vMinX, vMaxY, vMaxZ).setColor(color);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMinZ).setColor(color);
+
+        // Vertical edges
+        bufferbuilder.addVertex(vMinX, vMinY, vMinZ).setColor(color);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMinZ).setColor(color);
+
+        bufferbuilder.addVertex(vMaxX, vMinY, vMinZ).setColor(color);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMinZ).setColor(color);
+
+        bufferbuilder.addVertex(vMaxX, vMinY, vMaxZ).setColor(color);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMaxZ).setColor(color);
+
+        bufferbuilder.addVertex(vMinX, vMinY, vMaxZ).setColor(color);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMaxZ).setColor(color);
+
+        var meshdata = bufferbuilder.build();
+        if(meshdata != null) {
+            BufferUploader.drawWithShader(meshdata);
+        }
+
+        RenderSystem.enableCull();
+        RenderSystem.polygonOffset(0.0F, 0.0F);
+        RenderSystem.disablePolygonOffset();
+        RenderSystem.disableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+        RenderSystem.depthMask(true);
+    }
+
+    private static void renderLightVolume(Vec3i pos, int torchRange, Camera cam, int color)
+    {
+        // Logic is similar to vanillas LevelRenderer.renderWorldBorder()
+        var mc = Minecraft.getInstance();
+        var blockRenderDistance = mc.options.getEffectiveRenderDistance() * 16;
+        var torchVol = createVolume(pos, torchRange);
+        var playerVolume = createVolume(cam.getBlockPosition(), blockRenderDistance);
+        if(!playerVolume.intersects(torchVol)) return;
+
+        var camX = cam.getPosition().x;
+        var camZ = cam.getPosition().z;
+        var camY = cam.getPosition().y;
+
+        RenderSystem.enableBlend();
+        RenderSystem.enableDepthTest();
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ZERO, GlStateManager.DestFactor.ONE);
+        RenderSystem.setShaderTexture(0, FORCEFIELD_LOCATION);
+        RenderSystem.depthMask(Minecraft.useShaderTransparency());
+        // Set color multiplier
+        float red = (float)(color >> 16 & 255) / 255.0F;
+        float green = (float)(color >> 8 & 255) / 255.0F;
+        float blue = (float)(color & 255) / 255.0F;
+        RenderSystem.setShaderColor(red, green, blue, 1f);
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
+        // Offset is used to work around z-fighting issues
+        RenderSystem.polygonOffset(-3.0F, -3.0F);
+        RenderSystem.enablePolygonOffset();
+        // Render both sides
+        RenderSystem.disableCull();
+
+        BufferBuilder bufferbuilder = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+
+        var vMinX = (float)(torchVol.minX() - camX);
+        var vMaxX = (float)(torchVol.maxX() - camX);
+        var vMinY = (float)(torchVol.minY() - camY);
+        var vMaxY = (float)(torchVol.maxY() - camY);
+        var vMinZ = (float)(torchVol.minZ() - camZ);
+        var vMaxZ = (float)(torchVol.maxZ() - camZ);
+
+        var uv0 = (float)(Util.getMillis() % 3000L) / 3000.0F; // slide the texture over 3s
+        var uv1 = torchRange  + uv0;
+
+        // +X
+        bufferbuilder.addVertex(vMaxX, vMinY, vMinZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMaxZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMaxZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMinZ).setUv(uv0, uv1);
+
+        // -X
+        bufferbuilder.addVertex(vMinX, vMinY, vMinZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMinX, vMinY, vMaxZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMaxZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMinZ).setUv(uv0, uv1);
+
+        // +Z
+        bufferbuilder.addVertex(vMinX, vMinY, vMaxZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMaxZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMaxZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMaxZ).setUv(uv0, uv1);
+
+        // -Z
+        bufferbuilder.addVertex(vMinX, vMinY, vMinZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMinZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMinZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMinZ).setUv(uv0, uv1);
+
+        // +Y
+        bufferbuilder.addVertex(vMinX, vMaxY, vMinZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMinZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMaxZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMaxZ).setUv(uv0, uv1);
+
+        // -Y
+        bufferbuilder.addVertex(vMinX, vMinY, vMinZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMinZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMaxZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMinX, vMinY, vMaxZ).setUv(uv0, uv1);
+
+        var meshdata = bufferbuilder.build();
+        if(meshdata != null) {
+            BufferUploader.drawWithShader(meshdata);
+        }
+
+        RenderSystem.enableCull();
+        RenderSystem.polygonOffset(0.0F, 0.0F);
+        RenderSystem.disablePolygonOffset();
+        RenderSystem.disableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+        RenderSystem.depthMask(true);
+    }
+
+    private static final Map<Vec3i, Tuple<Integer, Integer>> volumeLights = new HashMap<>();
+    private static final Map<Vec3i, Integer> locationLights = new HashMap<>();
+
+    public static void showVolumeAt(Vec3i pos, int range, int color)
+    {
+        volumeLights.put(pos, new Tuple<>(range, color));
+    }
+
+    public static void removeVolumeAt(Vec3i pos)
+    {
+        volumeLights.remove(pos);
+    }
+
+    public static void showLocationAt(Vec3i pos, int color)
+    {
+        locationLights.put(pos, color);
+    }
+
+    public static void removeLocationAt(Vec3i pos)
+    {
+        locationLights.remove(pos);
+    }
+
+    public static void clearAll()
+    {
+        volumeLights.clear();
+        locationLights.clear();
+    }
+
+    public static void onRenderLevel(Camera camera) {
+        for (var light : volumeLights.entrySet())
+        {
+            renderLightVolume(light.getKey(), light.getValue().getA(), camera, light.getValue().getB());
+            renderWireframeCube(light.getKey(), light.getValue().getA(), light.getValue().getB(), camera);
+        }
+
+        for (var light : locationLights.entrySet())
+        {
+            renderTorchLocation(light.getKey(), light.getValue(), camera);
+            renderWireframeCube(light.getKey(), 0, light.getValue(), camera);
+        }
+    }
+
+    private static void renderTorchLocation(Vec3i pos, int color, Camera cam)
+    {
+        var camX = cam.getPosition().x;
+        var camZ = cam.getPosition().z;
+        var camY = cam.getPosition().y;
+
+        RenderSystem.enableBlend();
+        RenderSystem.disableDepthTest();
+        //RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ZERO, GlStateManager.DestFactor.ONE);
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+        RenderSystem.setShaderTexture(0, FORCEFIELD_LOCATION);
+        RenderSystem.depthMask(Minecraft.useShaderTransparency());
+
+        RenderSystem.applyModelViewMatrix();
+        float red = (float)(color >> 16 & 255) / 255.0F;
+        float green = (float)(color >> 8 & 255) / 255.0F;
+        float blue = (float)(color & 255) / 255.0F;
+        RenderSystem.setShaderColor(red, green, blue, 1f);
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
+        // Offset is used to work around z-fighting issues
+        RenderSystem.polygonOffset(-3.0F, -3.0F);
+        RenderSystem.enablePolygonOffset();
+        // Render both sides
+        RenderSystem.disableCull();
+        float slide = (float)(Util.getMillis() % 3000L) / 3000.0F;
+
+        var bufferbuilder = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+
+        var vMinX = (float)(pos.getX() - camX);
+        var vMaxX = (float)(pos.getX() - camX + 1);
+        var vMinY = (float)(pos.getY() - camY);
+        var vMaxY = (float)(pos.getY() - camY + 1);
+        var vMinZ = (float)(pos.getZ() - camZ);
+        var vMaxZ = (float)(pos.getZ() - camZ + 1);
+
+        var uv0 = 0;
+        var uv1 = 1;
+
+        // +X
+        bufferbuilder.addVertex(vMaxX, vMinY, vMinZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMaxZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMaxZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMinZ).setUv(uv0, uv1);
+
+        // -X
+        bufferbuilder.addVertex(vMinX, vMinY, vMinZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMinX, vMinY, vMaxZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMaxZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMinZ).setUv(uv0, uv1);
+
+        // +Z
+        bufferbuilder.addVertex(vMinX, vMinY, vMaxZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMaxZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMaxZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMaxZ).setUv(uv0, uv1);
+
+        // -Z
+        bufferbuilder.addVertex(vMinX, vMinY, vMinZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMinZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMinZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMinZ).setUv(uv0, uv1);
+
+        // +Y
+        bufferbuilder.addVertex(vMinX, vMaxY, vMinZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMinZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMaxX, vMaxY, vMaxZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMinX, vMaxY, vMaxZ).setUv(uv0, uv1);
+
+        // -Y
+        bufferbuilder.addVertex(vMinX, vMinY, vMinZ).setUv(uv1, uv1);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMinZ).setUv(uv1 , uv0);
+        bufferbuilder.addVertex(vMaxX, vMinY, vMaxZ).setUv(uv0, uv0);
+        bufferbuilder.addVertex(vMinX, vMinY, vMaxZ).setUv(uv0, uv1);
+
+        var meshdata = bufferbuilder.build();
+        if(meshdata != null) {
+            BufferUploader.drawWithShader(meshdata);
+        }
+
+        RenderSystem.enableCull();
+        RenderSystem.polygonOffset(0.0F, 0.0F);
+        RenderSystem.disablePolygonOffset();
+        RenderSystem.disableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+        RenderSystem.depthMask(true);
+    }
+}

--- a/common/src/main/java/net/xalcon/torchmaster/client/VolumeRendererOverlay.java
+++ b/common/src/main/java/net/xalcon/torchmaster/client/VolumeRendererOverlay.java
@@ -1,6 +1,5 @@
 package net.xalcon.torchmaster.client;
 
-import com.mojang.authlib.minecraft.client.MinecraftClient;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
@@ -11,15 +10,29 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.core.Vec3i;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Tuple;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
-import net.minecraft.world.phys.Vec3;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class VolumeRendererOverlay {
+    public static final int[] COLORS = {
+            0xFFE53935, // Red-ish
+            0xFFFFA020, // Orange
+            0xFFF4D03F, // Yellow-ish
+            0xFFA0FF20, // Lime
+            0xFF43A047, // Leafy Green
+            0xFF20FFA0, // Cyan
+            0xFF1E88E5, // Sky Blue
+            0xFF3F51B5, // Indigo
+            0xFFA020FF, // Violet
+            0xFFD81B60, // Magenta
+            0xFFF06292, // Pink
+            0xFF9C27B0  // Purple
+    };
+
+
     private static final ResourceLocation FORCEFIELD_LOCATION = ResourceLocation.fromNamespaceAndPath("minecraft", "textures/misc/forcefield.png");
 
     private record LightKey(ResourceLocation dimension, Vec3i pos) {
@@ -28,8 +41,9 @@ public class VolumeRendererOverlay {
         }
     }
 
-    private static final Map<LightKey, Tuple<Integer, Integer>> volumeLights = new HashMap<>();
-    private static final Map<LightKey, Integer> locationLights = new HashMap<>();
+    public record LightInfo(int colorIndex, int range, boolean showVolume, boolean showLocation) {}
+
+    private static final Map<LightKey, LightInfo> lights = new HashMap<>();
 
     private static BoundingBox createVolume(Vec3i pos, int halfRange)
     {
@@ -133,7 +147,7 @@ public class VolumeRendererOverlay {
         RenderSystem.depthMask(true);
     }
 
-    private static void renderLightVolume(Vec3i pos, int torchRange, Camera cam, int color)
+    private static void renderLightVolume(Vec3i pos, int torchRange, int color, Camera cam)
     {
         // Logic is similar to vanillas LevelRenderer.renderWorldBorder()
         var mc = Minecraft.getInstance();
@@ -225,50 +239,6 @@ public class VolumeRendererOverlay {
         RenderSystem.depthMask(true);
     }
 
-    public static void showVolumeAt(ResourceKey<Level> dimension, Vec3i pos, int range, int color)
-    {
-        volumeLights.put(new LightKey(dimension, pos), new Tuple<>(range, color));
-    }
-
-    public static void removeVolumeAt(ResourceKey<Level> dimension, Vec3i pos)
-    {
-        volumeLights.remove(new LightKey(dimension, pos));
-    }
-
-    public static void showLocationAt(ResourceKey<Level> dimension, Vec3i pos, int color)
-    {
-        locationLights.put(new LightKey(dimension, pos), color);
-    }
-
-    public static void removeLocationAt(ResourceKey<Level> dimension, Vec3i pos)
-    {
-        locationLights.remove(new LightKey(dimension, pos));
-    }
-
-    public static void clearAll()
-    {
-        volumeLights.clear();
-        locationLights.clear();
-    }
-
-    public static void onRenderLevel(ResourceKey<Level> dimension, Camera camera) {
-        for (var light : volumeLights.entrySet())
-        {
-            var key = light.getKey();
-            if(!dimension.location().equals(key.dimension)) continue; // Dont render stuff from different dimensions
-            renderLightVolume(key.pos, light.getValue().getA(), camera, light.getValue().getB());
-            renderWireframeCube(key.pos, light.getValue().getA(), light.getValue().getB(), camera);
-        }
-
-        for (var light : locationLights.entrySet())
-        {
-            var key = light.getKey();
-            if(!dimension.location().equals(key.dimension)) continue; // Dont render stuff from different dimensions
-            renderTorchLocation(key.pos, light.getValue(), camera);
-            renderWireframeCube(key.pos, 0, light.getValue(), camera);
-        }
-    }
-
     private static void renderTorchLocation(Vec3i pos, int color, Camera cam)
     {
         var camX = cam.getPosition().x;
@@ -355,5 +325,44 @@ public class VolumeRendererOverlay {
         RenderSystem.defaultBlendFunc();
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.depthMask(true);
+    }
+
+    public static LightInfo getLightOverlay(ResourceKey<Level> dimension, Vec3i pos)
+    {
+        return lights.get(new LightKey(dimension, pos));
+    }
+
+    public static void setLightOverlay(ResourceKey<Level> dimension, Vec3i pos, int colorIndex, int range, boolean showVolume, boolean showLocation) {
+        lights.put(new LightKey(dimension, pos), new LightInfo(colorIndex % COLORS.length, range, showVolume, showLocation));
+    }
+
+    public static void removeLightOverlay(ResourceKey<Level> dimension, Vec3i pos) {
+        lights.remove(new LightKey(dimension, pos));
+    }
+
+    public static void clearAll()
+    {
+        lights.clear();
+    }
+
+    public static void onRenderLevel(ResourceKey<Level> dimension, Camera camera) {
+        for(var light : lights.entrySet())
+        {
+            var key = light.getKey();
+            var info = light.getValue();
+            if(info.showVolume)
+            {
+                int color = COLORS[info.colorIndex];
+                renderLightVolume(key.pos, info.range, color, camera);
+                renderWireframeCube(key.pos, info.range, color, camera);
+            }
+
+            if(info.showLocation)
+            {
+                int color = COLORS[info.colorIndex];
+                renderTorchLocation(key.pos, color, camera);
+                renderWireframeCube(key.pos, 0, color, camera);
+            }
+        }
     }
 }

--- a/common/src/main/java/net/xalcon/torchmaster/client/gui/EntityBlockingLightSettingsScreen.java
+++ b/common/src/main/java/net/xalcon/torchmaster/client/gui/EntityBlockingLightSettingsScreen.java
@@ -1,0 +1,168 @@
+package net.xalcon.torchmaster.client.gui;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import net.xalcon.torchmaster.client.VolumeRendererOverlay;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class EntityBlockingLightSettingsScreen extends net.minecraft.client.gui.screens.Screen
+{
+
+    public static class ColorIconButton extends Button {
+
+        private final int colorRectWidth;
+        private final int colorRectHeight;
+
+        private int color;
+
+        protected ColorIconButton(int x, int y, int width, int height, Button.OnPress onPress, @Nullable Button.CreateNarration createNarration) {
+            super(x, y, width, height, Component.empty(), onPress, createNarration);
+            colorRectWidth = width - 4;
+            colorRectHeight = height - 4;
+        }
+
+        public void renderWidget(@NotNull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+            super.renderWidget(guiGraphics, mouseX, mouseY, partialTick);
+            int i = this.getX() + this.getWidth() / 2 - this.colorRectWidth / 2;
+            int j = this.getY() + this.getHeight() / 2 - this.colorRectHeight / 2;
+            guiGraphics.fill(i + 1, j + 1, i + colorRectWidth - 1, j + colorRectHeight - 1, 0xFF000000);
+            guiGraphics.fill(i + 2, j + 2, i + colorRectWidth - 2, j + colorRectHeight - 2, color);
+        }
+
+        public void renderString(@NotNull GuiGraphics guiGraphics, @NotNull Font font, int color) {
+        }
+
+        public void setColor(int color) {
+            this.color = color;
+        }
+    }
+
+
+    private static final int BUTTON_WIDTH = 200;
+    private static final int BUTTON_HEIGHT = 20;
+    private static final int PANEL_WIDTH = 220;
+    private static final int PANEL_HEIGHT = 130;
+
+    private final BlockPos torchPos;
+    private boolean overlayOn;
+    private int range;
+    private Button toggleButton;
+    private ColorIconButton colorCycleButton;
+
+    public EntityBlockingLightSettingsScreen(BlockPos torchPos, int range)
+    {
+        super(Component.translatable("screen.torchmaster.volume_gui.title"));
+        this.torchPos = torchPos.immutable();
+        this.range = range;
+    }
+
+    @Override
+    protected void init()
+    {
+        super.init();
+
+        this.overlayOn = readCurrentOverlayState();
+
+        int centerX = this.width / 2;
+        int panelTop = (this.height - PANEL_HEIGHT) / 2;
+
+        this.toggleButton = Button.builder(toggleLabel(), b -> onToggle())
+                .bounds(centerX - BUTTON_WIDTH / 2, panelTop + 60, BUTTON_WIDTH, BUTTON_HEIGHT)
+                .build();
+        this.addRenderableWidget(this.toggleButton);
+
+        //noinspection SuspiciousNameCombination
+        colorCycleButton = new ColorIconButton(centerX + BUTTON_WIDTH / 2, panelTop + 60, BUTTON_HEIGHT, BUTTON_HEIGHT, b -> onColorCycle(), null);
+        colorCycleButton.visible = this.overlayOn;
+        this.addRenderableWidget(colorCycleButton);
+
+        this.addRenderableWidget(Button.builder(CommonComponents.GUI_DONE, b -> this.onClose())
+                .bounds(centerX - BUTTON_WIDTH / 2 + 1, panelTop + PANEL_HEIGHT - 28, BUTTON_WIDTH, BUTTON_HEIGHT)
+                .build());
+
+        ClientLevel level = Minecraft.getInstance().level;
+        if (level == null) return;
+        var info = VolumeRendererOverlay.getLightOverlay(level.dimension(), this.torchPos);
+        if(info != null)
+        {
+            colorCycleButton.setColor(VolumeRendererOverlay.COLORS[info.colorIndex()]);
+        }
+    }
+
+    private boolean readCurrentOverlayState()
+    {
+        ClientLevel level = Minecraft.getInstance().level;
+        if (level == null) return false;
+
+        return VolumeRendererOverlay.getLightOverlay(level.dimension(), this.torchPos) != null;
+    }
+
+    private void onToggle()
+    {
+        ClientLevel level = Minecraft.getInstance().level;
+        if (level == null) return;
+
+        var info = VolumeRendererOverlay.getLightOverlay(level.dimension(), this.torchPos);
+        if(info == null)
+        {
+            VolumeRendererOverlay.setLightOverlay(level.dimension(), this.torchPos, 0, range, true, true);
+            colorCycleButton.setColor(VolumeRendererOverlay.COLORS[0]);
+            this.overlayOn = true;
+        }
+        else
+        {
+            VolumeRendererOverlay.removeLightOverlay(level.dimension(), this.torchPos);
+            this.overlayOn = false;
+            colorCycleButton.setColor(VolumeRendererOverlay.COLORS[info.colorIndex()]);
+        }
+        colorCycleButton.visible = this.overlayOn;
+        toggleButton.setMessage(toggleLabel());
+    }
+
+    private void onColorCycle() {
+        ClientLevel level = Minecraft.getInstance().level;
+        if (level == null) return;
+        if (!this.overlayOn) return; // This shouldn't be possible... but just in case
+
+        var info = VolumeRendererOverlay.getLightOverlay(level.dimension(), this.torchPos);
+        int colorIndex = (info.colorIndex() + 1) % VolumeRendererOverlay.COLORS.length;
+        VolumeRendererOverlay.setLightOverlay(level.dimension(), this.torchPos, colorIndex, info.range(), info.showVolume(), info.showLocation());
+        colorCycleButton.setColor(VolumeRendererOverlay.COLORS[colorIndex]);
+    }
+
+    private Component toggleLabel()
+    {
+        return this.overlayOn
+                ? Component.translatable("screen.torchmaster.volume_gui.toggle_on")
+                : Component.translatable("screen.torchmaster.volume_gui.toggle_off");
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick)
+    {
+        this.renderBackground(graphics, mouseX, mouseY, partialTick);
+        super.render(graphics, mouseX, mouseY, partialTick);
+
+        int centerX = this.width / 2;
+        int panelTop = (this.height - PANEL_HEIGHT) / 2;
+
+        graphics.drawCenteredString(this.font, this.title, centerX, panelTop + 10, 0xFFFFFFFF);
+        graphics.drawCenteredString(this.font,
+                Component.translatable("screen.torchmaster.volume_gui.range", this.range),
+                centerX, panelTop + 35, 0xFFCCCCCC);
+    }
+
+    @Override
+    public boolean isPauseScreen()
+    {
+        return false;
+    }
+}
+

--- a/common/src/main/resources/assets/torchmaster/lang/en_us.json
+++ b/common/src/main/resources/assets/torchmaster/lang/en_us.json
@@ -32,6 +32,11 @@
     "text.config.torchmaster-config.option.megaTorchEntityBlockListOverrides": "Megatorch Entity Blocklist Overrides",
     "text.config.torchmaster-config.option.megaTorchEntityBlockListOverrides.tooltip": "See Torchmaster Wiki on Github for details",
     "text.config.torchmaster-config.option.dreadLampEntityBlockListOverrides": "Dreadlamp Entity Blocklist Overrides",
-    "text.config.torchmaster-config.option.dreadLampEntityBlockListOverrides.tooltip": "See Torchmaster Wiki on Github for details"
+    "text.config.torchmaster-config.option.dreadLampEntityBlockListOverrides.tooltip": "See Torchmaster Wiki on Github for details",
+
+    "screen.torchmaster.volume_gui.title": "Torchmaster Volume Range Display",
+    "screen.torchmaster.volume_gui.toggle_on": "Turn range display off",
+    "screen.torchmaster.volume_gui.toggle_off": "Turn range display on",
+    "screen.torchmaster.volume_gui.range": "Effective Range in each direction: §a%s§r Blocks"
 }
 

--- a/fabric/src/main/java/net/xalcon/torchmaster/TorchmasterFabricClient.java
+++ b/fabric/src/main/java/net/xalcon/torchmaster/TorchmasterFabricClient.java
@@ -21,7 +21,7 @@ public class TorchmasterFabricClient implements ClientModInitializer {
         {
             ClientLevel level = Minecraft.getInstance().level;
             if (level == null) return;
-            VolumeRendererOverlay.onRenderLevel(ctx.camera());
+            VolumeRendererOverlay.onRenderLevel(level.dimension(), ctx.camera());
         });
     }
 }

--- a/fabric/src/main/java/net/xalcon/torchmaster/TorchmasterFabricClient.java
+++ b/fabric/src/main/java/net/xalcon/torchmaster/TorchmasterFabricClient.java
@@ -4,12 +4,24 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.RenderType;
+import net.xalcon.torchmaster.client.VolumeRendererOverlay;
+import net.xalcon.torchmaster.platform.Services;
 
 @Environment(EnvType.CLIENT)
 public class TorchmasterFabricClient implements ClientModInitializer {
     public void onInitializeClient()
     {
         BlockRenderLayerMap.INSTANCE.putBlock(ModRegistry.blockDreadLamp.get(), RenderType.cutout());
+
+        WorldRenderEvents.AFTER_TRANSLUCENT.register(ctx ->
+        {
+            ClientLevel level = Minecraft.getInstance().level;
+            if (level == null) return;
+            VolumeRendererOverlay.onRenderLevel(ctx.camera());
+        });
     }
 }

--- a/fabric/src/main/java/net/xalcon/torchmaster/TorchmasterFabricClient.java
+++ b/fabric/src/main/java/net/xalcon/torchmaster/TorchmasterFabricClient.java
@@ -4,6 +4,7 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -22,6 +23,10 @@ public class TorchmasterFabricClient implements ClientModInitializer {
             ClientLevel level = Minecraft.getInstance().level;
             if (level == null) return;
             VolumeRendererOverlay.onRenderLevel(level.dimension(), ctx.camera());
+        });
+
+        ClientPlayConnectionEvents.DISCONNECT.register((phase, listener) -> {
+            VolumeRendererOverlay.clearAll();
         });
     }
 }

--- a/neoforge/src/main/java/net/xalcon/torchmaster/TorchmasterClientEventHandler.java
+++ b/neoforge/src/main/java/net/xalcon/torchmaster/TorchmasterClientEventHandler.java
@@ -1,0 +1,18 @@
+package net.xalcon.torchmaster;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import net.xalcon.torchmaster.client.VolumeRendererOverlay;
+
+@EventBusSubscriber(value = Dist.CLIENT, modid = Constants.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
+public class TorchmasterClientEventHandler {
+    @SubscribeEvent
+    public static void onRenderLevelStageEvent(RenderLevelStageEvent event)
+    {
+        if(event.getStage() != RenderLevelStageEvent.Stage.AFTER_WEATHER) return;
+
+        VolumeRendererOverlay.onRenderLevel(event.getCamera());
+    }
+}

--- a/neoforge/src/main/java/net/xalcon/torchmaster/TorchmasterClientEventHandler.java
+++ b/neoforge/src/main/java/net/xalcon/torchmaster/TorchmasterClientEventHandler.java
@@ -1,5 +1,6 @@
 package net.xalcon.torchmaster;
 
+import net.minecraft.client.Minecraft;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -12,7 +13,8 @@ public class TorchmasterClientEventHandler {
     public static void onRenderLevelStageEvent(RenderLevelStageEvent event)
     {
         if(event.getStage() != RenderLevelStageEvent.Stage.AFTER_WEATHER) return;
-
-        VolumeRendererOverlay.onRenderLevel(event.getCamera());
+        var mc = Minecraft.getInstance();
+        if(mc.player == null) return;
+        VolumeRendererOverlay.onRenderLevel(mc.player.level().dimension(), event.getCamera());
     }
 }

--- a/neoforge/src/main/java/net/xalcon/torchmaster/TorchmasterClientEventHandler.java
+++ b/neoforge/src/main/java/net/xalcon/torchmaster/TorchmasterClientEventHandler.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import net.xalcon.torchmaster.client.VolumeRendererOverlay;
 
@@ -16,5 +17,11 @@ public class TorchmasterClientEventHandler {
         var mc = Minecraft.getInstance();
         if(mc.player == null) return;
         VolumeRendererOverlay.onRenderLevel(mc.player.level().dimension(), event.getCamera());
+    }
+
+    @SubscribeEvent
+    private static void onPlayerLogin(ClientPlayerNetworkEvent.LoggingOut event)
+    {
+        VolumeRendererOverlay.clearAll();
     }
 }

--- a/neoforge/src/main/java/net/xalcon/torchmaster/TorchmasterNeoforge.java
+++ b/neoforge/src/main/java/net/xalcon/torchmaster/TorchmasterNeoforge.java
@@ -38,6 +38,10 @@ public class TorchmasterNeoforge
     private static void loadComplete(LevelEvent.Load event)
     {
         Torchmaster.onWorldLoaded();
+        if(event.getLevel().isClientSide())
+        {
+
+        }
     }
 
     private void doClientStuff(final FMLClientSetupEvent event) {

--- a/neoforge/src/main/java/net/xalcon/torchmaster/TorchmasterNeoforge.java
+++ b/neoforge/src/main/java/net/xalcon/torchmaster/TorchmasterNeoforge.java
@@ -38,10 +38,6 @@ public class TorchmasterNeoforge
     private static void loadComplete(LevelEvent.Load event)
     {
         Torchmaster.onWorldLoaded();
-        if(event.getLevel().isClientSide())
-        {
-
-        }
     }
 
     private void doClientStuff(final FMLClientSetupEvent event) {


### PR DESCRIPTION
Add a client-side only range visualizer to the Mega Torch and Dreadlamp. The Range Visualization can be toggled via a Block GUI that opens when interacting with the block with an empty hand.
The gui allows turning the range display on and off. When turned on, the color can be cycled through.

## Behavior
The visualization shows 2 boxes, one for the torch itself and one for the full volume. The torch itself is visible through terrain. This may not be super useful for now, but the plan is to allow toggling this via server commands to easier find nearby torches without directly interacting with them.

The visualization is only visible to the player enabling the feature. The server is not involved in this. It remains active across dimension hops but automatically turns off when disconnecting from the world.